### PR TITLE
Fixing Import list on data-formats-and-types

### DIFF
--- a/pages/data-formats-and-types.md
+++ b/pages/data-formats-and-types.md
@@ -99,8 +99,9 @@ Removing
 * `DomCharacterData::deleteData()`
 
 Import 
+
 * `dom_import_simplexml($sxml)`
-* `simplexml_import_dom($dom);`
+* `simplexml_import_dom($dom)`
 
 
 * * *


### PR DESCRIPTION
Fixing the "Import" list on data-formats-and-types page, I forgeted to put a blank space on the last PR.